### PR TITLE
fixed missing parenthesis

### DIFF
--- a/src/vegafx/example.clj
+++ b/src/vegafx/example.clj
@@ -114,4 +114,4 @@
           timer  (future (Thread/sleep 3000) (when-not (realized? res)
                                                (do (deliver res :timed-out)
                                                    (future-cancel task))))]
-      (println [f @res]))))
+      (println [f @res])))))


### PR DESCRIPTION
A closing ')' was missing in examples